### PR TITLE
feat: upgrade to version 2.0.0 with support for Express 5.x

### DIFF
--- a/.github/workflows/main-PR.yml
+++ b/.github/workflows/main-PR.yml
@@ -1,24 +1,28 @@
-name: Performing checks.
+name: CI
 
 on:
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
-    - run: npm ci
-    - run: cd sample-app && npm ci && cd ..
-    - run: npm i -g .
-    - run: npm test
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      # Single install: brings in Express 4.x (express-v4) and 5.x (express-v5)
+      # as devDependencies via npm aliases — no separate sample-app install needed.
+      - run: npm ci
+
+      - run: npm test

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,3 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
-# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
-
 name: Publish ERC
 
 on:
@@ -8,34 +5,39 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node-version: [20.x]
-        
+        node-version: [18.x, 20.x, 22.x]
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          cache: npm
+
       - run: npm ci
-      - run: cd sample-app && npm ci && cd ..
-      - run: npm i -g .
       - run: npm test
 
   publish-npm:
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
-          cache: 'npm'
+          node-version: 20.x
+          cache: npm
           registry-url: https://registry.npmjs.org/
+
       - run: npm ci
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,182 +1,129 @@
 #!/usr/bin/env node
-const chalk = require("chalk");
-const boxen = require("boxen");
-const yargs = require("yargs");
-const figlet = require("figlet");
-const path = require("path");
-const fs = require("fs");
-const registeredRoutes = require("../plugin");
+'use strict';
 
-const banner = chalk.yellow(figlet.textSync("ERC", { horizontalLayout: "full" }));
+const chalk = require('chalk');
+const boxen = require('boxen');
+const yargs = require('yargs');
+const figlet = require('figlet');
+const path = require('path');
+const fs = require('fs');
+const registeredRoutes = require('../plugin');
 
-const usage = chalk.keyword("violet")(
-    `${banner}\n Usage: erc -p <path>  -v <variable> -o <output> -f <output-file> -j <package.json> \n
-    ${boxen(
-        chalk.green(
-            "\n" +
-            "An express JS plugin to print registered routes of an expressJS app." +
-            "\n"
-        ),
-        { padding: 1, borderColor: "green", dimBorder: true }
-    )}\n`
+const banner = chalk.yellow(figlet.textSync('ERC', { horizontalLayout: 'full' }));
+
+const usage = chalk.keyword('violet')(
+  `${banner}\n Usage: erc -p <path> -v <variable> -o <output> [-f <output-file>]\n\n${boxen(
+    chalk.green('\n An express JS plugin to print registered routes of an expressJS app.\n'),
+    { padding: 1, borderColor: 'green', dimBorder: true }
+  )}\n`
 );
 
-const isOutputFileRequired = () => {
-    const optionsIndex = process.argv.slice(2).indexOf("-o") !== -1 ? process.argv.slice(2).indexOf("-o") : process.argv.slice(2).indexOf("-output");
-    switch (process.argv.slice(2)[optionsIndex + 1]) {
-        case "--help":
-            return false;
-        case "print":
-            return false;
-        case "json":
-            return true;
-        default:
-            if (optionsIndex !== -1)
-                console.log(chalk.red("Invalid output type."));
-            return false;
-    }
-}
-
 const options = yargs
-    .usage(usage)
-    .help("help")
-    .option("path", {
-        alias: "p",
-        describe: "Path to ExpressJS App file.",
-        type: "string",
-        demandOption: true,
-    })
-    .option("variable", {
-        alias: "v",
-        describe: "Variable name of ExpressJS App.",
-        type: "string",
-        demandOption: true,
-    })
-    .option("output", {
-        alias: "o",
-        describe: "Output type path.",
-        type: "string",
-        demandOption: true,
-    })
-    .option("output-file", {
-        alias: "f",
-        describe: "Output file path.",
-        type: "string",
-        demandOption: isOutputFileRequired(),
-    })
-    .option("packageJSON", {
-        alias: "j",
-        describe: "Path to package.json file.",
-        type: "string",
-        demandOption: true,
-    })
-    .example("erc -p ./app.js -v app -o print -j package.json", "Print all registered routes.")
-    .example("erc --path ./app.js --variable app --output print --packageJSON package.json", "Print all registered routes.")
-    .example("erc -p ./app.js -v app -o json -f routes.json -j package.json", "Write all registered routes into a JSON file.")
-    .example("erc --path ./app.js --variable app --output json --output-file routes.json --packageJSON package.json", "Write all registered routes into a JSON file.")
-    .argv;
+  .usage(usage)
+  .help('help')
+  .option('path', {
+    alias: 'p',
+    describe: 'Path to ExpressJS app file.',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('variable', {
+    alias: 'v',
+    describe: 'Variable name of the ExpressJS app.',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('output', {
+    alias: 'o',
+    describe: 'Output type: print | json',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('output-file', {
+    alias: 'f',
+    describe: 'Output file path (required when --output is json).',
+    type: 'string',
+  })
+  .option('packageJSON', {
+    alias: 'j',
+    describe: 'Path to package.json (deprecated — no longer required).',
+    type: 'string',
+  })
+  .example('erc -p ./app.js -v app -o print', 'Print all registered routes.')
+  .example('erc -p ./app.js -v app -o json -f routes.json', 'Write all registered routes to a JSON file.')
+  .argv;
 
-let { path: _path, variable, output, outputFile, packageJSON } = options;
+const { path: _path, variable, output, outputFile } = options;
 
-_path = path.resolve(_path);
-packageJSON = require(path.resolve(packageJSON));
-if (!fs.existsSync(_path)) {
-    yargs.showHelp();
-    console.log(`\n\n${chalk.red("File not found")} => ${_path}\n`);
-    return;
+if (output === 'json' && !outputFile) {
+  console.log(chalk.red('Output file (-f / --output-file) is required when output type is json.'));
+  yargs.showHelp();
+  process.exit(1);
 }
+
+const resolvedPath = path.resolve(_path);
+if (!fs.existsSync(resolvedPath)) {
+  console.log(`\n${chalk.red('File not found')} => ${resolvedPath}\n`);
+  process.exit(1);
+}
+
 let app = null;
-const data = fs.readFileSync(_path, "utf8");
-if (data.includes("module.exports")) {
-    const imports = require(_path);
-    if (Object.keys(imports).filter((key) => key === variable).length === 1) {
-        app = imports[variable];
-    } else {
-        console.log(chalk.red(`Unable to import ExpressJS App variable properly.\n\nExport the app variable in ${_path} as ${data} \n\nmodule.exports = { ${variable} };`));
-        return;
-    }
-} else {
-    const update = `${data}\nmodule.exports = { ${variable} };`;
-    const tempFileName = `${_path.substring(0, _path.lastIndexOf("/"))}/.temp.${Math.floor(Math.random() * 1000000)}.js`;
-    fs.writeFileSync(tempFileName, update);
-    const imports = require(path.resolve(tempFileName));
+const source = fs.readFileSync(resolvedPath, 'utf8');
+
+if (source.includes('module.exports')) {
+  const imports = require(resolvedPath);
+  if (Object.prototype.hasOwnProperty.call(imports, variable)) {
     app = imports[variable];
-    fs.unlinkSync(tempFileName);
-}
-if (app == null) {
-    console.log(chalk.red("Unable to link with Express App properly."));
-    return;
-}
-const routes = registeredRoutes(app, packageJSON);
-if (output) {
-    switch (output) {
-        case "json":
-            fs.writeFileSync(outputFile, JSON.stringify({ routes }, null, 2));
-            break;
-        case "print":
-            routes.map((route) => {
-                const _route = route.split("   =>   ");
-                const method = _route[0];
-                const __path = _route[1];
-                printRoute(method, __path);
-            });
-            break;
-        default:
-            console.log(chalk.red("Invalid output type."));
-            break;
-    }
+  } else {
+    console.log(chalk.red(
+      `Export '${variable}' not found in ${resolvedPath}.\n\nMake sure the app is exported:\n\n  module.exports = { ${variable} };`
+    ));
+    process.exit(1);
+  }
 } else {
-    routes.map((route) => {
-        const _route = route.split(" ");
-        const method = _route[0];
-        const __path = _route[1];
-        printRoute(method, __path);
-    });
+  const tempFile = path.join(
+    path.dirname(resolvedPath),
+    `.temp.${Date.now()}.${Math.floor(Math.random() * 1e6)}.js`
+  );
+  try {
+    fs.writeFileSync(tempFile, `${source}\nmodule.exports = { ${variable} };`);
+    app = require(path.resolve(tempFile))[variable];
+  } finally {
+    try { fs.unlinkSync(tempFile); } catch (_) {}
+  }
 }
 
-function printRoute(method, __path) {
-    switch (method) {
-        case "GET":
-            console.log(
-                `${chalk.bgGrey(chalk.greenBright(method))}\t${chalk.whiteBright(
-                    __path
-                )}`
-            );
-            break;
-        case "POST":
-            console.log(
-                `${chalk.bgGrey(chalk.blueBright(method))}\t${chalk.whiteBright(
-                    __path
-                )}`
-            );
-            break;
-        case "PUT":
-            console.log(
-                `${chalk.bgGrey(chalk.yellowBright(method))}\t${chalk.whiteBright(
-                    __path
-                )}`
-            );
-            break;
-        case "PATCH":
-            console.log(
-                `${chalk.bgGrey(chalk.magentaBright(method))}\t${chalk.whiteBright(
-                    __path
-                )}`
-            );
-            break;
-        case "DELETE":
-            console.log(
-                `${chalk.bgGrey(chalk.redBright(method))}\t${chalk.whiteBright(
-                    __path
-                )}`
-            );
-            break;
-        default:
-            console.log(
-                `${chalk.bgGrey(chalk.grayBright(method))}\t${chalk.whiteBright(
-                    __path
-                )}`
-            );
-            break;
-    }
+if (app == null) {
+  console.log(chalk.red(`Unable to read the Express app from variable '${variable}'.`));
+  process.exit(1);
+}
+
+const routes = registeredRoutes(app, null);
+
+switch (output) {
+  case 'json':
+    fs.writeFileSync(outputFile, JSON.stringify({ routes }, null, 2));
+    break;
+  case 'print':
+    routes.forEach(route => {
+      const sep = '   =>   ';
+      const idx = route.indexOf(sep);
+      printRoute(route.slice(0, idx), route.slice(idx + sep.length));
+    });
+    break;
+  default:
+    console.log(chalk.red(`Invalid output type '${output}'. Use 'print' or 'json'.`));
+    process.exit(1);
+}
+
+function printRoute(method, routePath) {
+  const methodColors = {
+    GET:    chalk.greenBright,
+    POST:   chalk.blueBright,
+    PUT:    chalk.yellowBright,
+    PATCH:  chalk.magentaBright,
+    DELETE: chalk.redBright,
+  };
+  const color = methodColors[method] || chalk.gray;
+  console.log(`${chalk.bgGrey(color(method))}\t${chalk.whiteBright(routePath)}`);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "expressjs-route-coverage",
-  "version": "1.0.9",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "expressjs-route-coverage",
-      "version": "1.0.9",
+      "version": "1.2.3",
       "license": "ISC",
       "dependencies": {
         "boxen": "^5.1.2",
@@ -18,7 +18,23 @@
         "erc": "bin/index.js"
       },
       "devDependencies": {
+        "express-v4": "npm:express@^4.21.0",
+        "express-v5": "npm:express@^5.0.0",
         "mocha": "^10.2.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/ansi-align": {
@@ -79,6 +95,13 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -92,6 +115,47 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/boxen": {
@@ -141,6 +205,47 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
@@ -241,6 +346,56 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
     "node_modules/decamelize": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
@@ -253,6 +408,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -262,10 +438,75 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -274,6 +515,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -285,6 +533,384 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v4": {
+      "name": "express",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5": {
+      "name": "express",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v5/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/express-v5/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-v5/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-v5/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/express-v5/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/express-v5/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v5/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/express-v5/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express-v5/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/express-v5/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-v5/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/figlet": {
@@ -308,6 +934,25 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/find-up": {
@@ -335,6 +980,26 @@
         "flat": "cli.js"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -355,12 +1020,61 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -417,12 +1131,51 @@
         "node": "*"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/he": {
@@ -432,6 +1185,40 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/inflight": {
@@ -449,6 +1236,16 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -509,6 +1306,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -562,6 +1366,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -698,6 +1578,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
@@ -710,6 +1597,16 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -717,6 +1614,32 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -758,6 +1681,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -776,6 +1709,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -788,6 +1728,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -795,6 +1765,32 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/readdirp": {
@@ -817,6 +1813,59 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/router/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -837,6 +1886,45 @@
         }
       ]
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -844,6 +1932,115 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-width": {
@@ -905,6 +2102,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/type-fest": {
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -914,6 +2121,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expressjs-route-coverage",
-  "version": "1.2.3",
+  "version": "2.0.0",
   "description": "An express JS plugin to print registered routes of an expressJS app.",
   "main": "index.js",
   "bin": {
@@ -8,6 +8,14 @@
   },
   "scripts": {
     "test": "mocha"
+  },
+  "mocha": {
+    "spec": [
+      "test/plugin.test.js",
+      "test/cli.test.js"
+    ],
+    "timeout": 15000,
+    "reporter": "spec"
   },
   "repository": {
     "type": "git",
@@ -31,6 +39,8 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "express-v4": "npm:express@^4.21.0",
+    "express-v5": "npm:express@^5.0.0",
     "mocha": "^10.2.0"
   }
 }

--- a/plugin.js
+++ b/plugin.js
@@ -1,59 +1,238 @@
-function registeredRoutes(app, packageJSON) {
-  const version = packageJSON.dependencies.express;
-  const regex = /^[^]?(4)/;
-  const matchedRegex = version.match(regex);
-  if (!matchedRegex || matchedRegex[1] !== "4") {
-    console.log("Only Express 4.x is supported.");
-    return [];
+'use strict';
+
+function registeredRoutes(app, _packageJSON) {
+  // Express 4.x uses lazy router init; 5.x does not expose lazyrouter
+  if (typeof app.lazyrouter === 'function') {
+    try { app.lazyrouter(); } catch (_) {}
   }
-  return getRoutes(app);
+
+  // Express 3.x: routes stored as { get: [{path,...}], post: [...] }
+  if (app.routes && typeof app.routes === 'object' && !app._router) {
+    return getRoutesV3(app);
+  }
+
+  const router = getRouter(app);
+  if (!router || !Array.isArray(router.stack)) return [];
+
+  return extractFromStack(router.stack, '');
 }
 
-function getRoutes(app) {
-  // Use reduce to accumulate routes into a single array
-  return app._router.stack.reduce((routes, layer) => {
-    return routes.concat(getRoutesFromLayer(layer, ''));
-  }, []);
+// Safely resolve the internal router across Express versions.
+// Express 4.x: app._router (app.router throws a deprecation error on 4.x)
+// Express 5.x: app.router  (app._router is undefined)
+function getRouter(app) {
+  if (app._router && Array.isArray(app._router.stack)) return app._router;
+
+  // Only attempt app.router when _router is absent to avoid the Express 4.x error
+  if (!app._router) {
+    try {
+      const r = app.router;
+      if (r && Array.isArray(r.stack)) return r;
+    } catch (_) {}
+  }
+
+  return null;
 }
 
-function getRoutesFromLayer(layer, parentPath) {
-  // If this layer has a route, format it as 'METHOD   =>   /path'
+function getRoutesV3(app) {
+  return Object.keys(app.routes).flatMap(method =>
+    app.routes[method].map(route => fmt(method, normalizePath(route.path)))
+  );
+}
+
+function extractFromStack(stack, prefix) {
+  return stack.flatMap(layer => extractFromLayer(layer, prefix));
+}
+
+function extractFromLayer(layer, prefix) {
   if (layer.route) {
-    const path = layer.route.path;
-    const methods = Object.keys(layer.route.methods);
-    // Format each method with its path
-    return methods.map((method) => `${method.toUpperCase()}   =>   ${ensureSlash(parentPath + path)}`);
+    // Express 5.x allows app.get(['/a', '/b'], handler) — path may be an array
+    const paths = Array.isArray(layer.route.path) ? layer.route.path : [layer.route.path];
+    const methods = Object.keys(layer.route.methods).filter(m => layer.route.methods[m]);
+    return paths.flatMap(p =>
+      methods.map(m => fmt(m, normalizePath(prefix + p)))
+    );
   }
 
-  // If this layer is a nested router, process its stack recursively
-  if (layer.name === 'router' && layer.handle && layer.handle.stack) {
-    const nestedPath = ensureSlash(parentPath + extractPathFromRegexp(layer.regexp));  // Convert regex to path string
-    return layer.handle.stack.reduce((nestedRoutes, nestedLayer) => {
-      return nestedRoutes.concat(getRoutesFromLayer(nestedLayer, nestedPath));
-    }, []);
+  if (layer.handle && Array.isArray(layer.handle.stack)) {
+    const mountPath = getMountPath(layer);
+    return extractFromStack(layer.handle.stack, prefix + mountPath);
   }
 
   return [];
 }
 
-// Ensure correct slashing between parentPath and path segments
-function ensureSlash(path) {
-  if (!path.startsWith('/')) {
-    path = '/' + path;  // Ensure the path starts with a '/'
+function getMountPath(layer) {
+  // Express 4.x: layer.regexp with optional fast-path flags
+  if (layer.regexp) {
+    if (layer.regexp.fast_slash) return '/';
+    if (layer.regexp.fast_star) return '/*';
+    return parsePath(layer.regexp.source, layer.keys || []);
   }
-  return path.replace(/\/+/g, '/');  // Ensure there's exactly one slash between parts
+
+  // Express 5.x: layer.matchers (closures over a compiled regexp) + layer.slash for '/'
+  if (layer.matchers) {
+    if (layer.slash) return '/';
+    return extractPathFromMatcher(layer.matchers[0]);
+  }
+
+  return '/';
 }
 
-// Helper function to convert Express's path regex to a string
-function extractPathFromRegexp(regexp) {
-  const path = regexp
-    .toString()
-    .replace('/^\\/', '/')  // Ensure path starts with '/'
-    .replace('\\/?(?=\\/|$)/i', '')  // Remove end regex characters
-    .replace(/\\\//g, '/')  // Convert escaped slashes to normal slashes
-    .replace(/\/$/, '');  // Remove trailing slash
-  return path;
+// Express 5.x stores the compiled regexp inside the matcher closure.
+// Recover it by briefly intercepting RegExp.prototype.exec — the first call the
+// matcher makes always invokes exec even on a non-matching probe path.
+function extractPathFromMatcher(matcherFn) {
+  if (typeof matcherFn !== 'function') return '/';
+
+  let capturedRegexp = null;
+  const originalExec = RegExp.prototype.exec;
+
+  RegExp.prototype.exec = function interceptExec() {
+    RegExp.prototype.exec = originalExec;
+    capturedRegexp = this;
+    return originalExec.apply(this, arguments);
+  };
+
+  try {
+    matcherFn('/');
+  } catch (_) {
+    // ignore
+  } finally {
+    RegExp.prototype.exec = originalExec;
+  }
+
+  if (!capturedRegexp) return '/';
+  return parsePath(capturedRegexp.source, []);
 }
 
+// Parse the mount path out of an Express layer regexp source string.
+//
+// Handles three formats:
+//   Express 4.x static  (path-to-regexp@0.1.x): ^\/api\/?(?=\/|$)
+//   Express 4.x param:                           ^\/orgs(?:\/([^/]+?))\/?(?=\/|$)
+//   Express 5.x         (path-to-regexp@8.x):    ^(?:\/api)(?:\/$)?(?=\/|$)
+//
+// The `keys` array (from layer.keys) supplies parameter names for capture groups.
+// When keys is empty (Express 5.x mount layers), params are named :param0, :param1, …
+function parsePath(source, keys) {
+  let rest = source.startsWith('^') ? source.slice(1) : source;
+
+  // Express 5.x wraps the path literal in a single outer (?:…) group.
+  // Unwrap only when it is NOT itself a parameter wrapper.
+  if (rest.startsWith('(?:') && !isParamWrapper(rest)) {
+    const inner = unwrapNonCapturingGroup(rest);
+    if (inner !== null) rest = inner;
+  }
+
+  const parts = [];
+  let ki = 0;
+
+  while (rest.length > 0) {
+    // Escaped slash (\/)
+    if (rest.startsWith('\\/')) {
+      if (rest[2] === '?') break; // \/? = optional trailing slash — suffix starts here
+      parts.push('/');
+      rest = rest.slice(2);
+      continue;
+    }
+
+    // Unescaped / — defensive against unusual regexp sources
+    if (rest[0] === '/') {
+      parts.push('/');
+      rest = rest.slice(1);
+      continue;
+    }
+
+    // Non-capturing group that wraps a path parameter: (?:\/captureGroup)?
+    // Express 4.x uses this form for named params, e.g. (?:\/([^/]+?))
+    if (rest.startsWith('(?:') && isParamWrapper(rest)) {
+      rest = rest.slice(3);     // skip (?:
+      parts.push('/');
+      rest = rest.slice(2);     // skip \/
+      // consume the inner capture group
+      let depth = 0, i = 0;
+      while (i < rest.length) {
+        if (rest[i] === '(') depth++;
+        else if (rest[i] === ')' && --depth === 0) { i++; break; }
+        i++;
+      }
+      rest = rest.slice(i);
+      if (rest[0] === ')') rest = rest.slice(1); // close the outer (?:
+      const isOptional = rest[0] === '?';
+      if (isOptional) rest = rest.slice(1);
+      const key = keys[ki++];
+      parts.push(`:${key ? key.name : `param${ki - 1}`}${isOptional ? '?' : ''}`);
+      continue;
+    }
+
+    // Non-capturing group or lookahead that is NOT a param wrapper → suffix, stop
+    if (rest.startsWith('(?:') || rest.startsWith('(?=') || rest.startsWith('(?!')) break;
+
+    // Bare capturing group → route parameter (Express 5.x unwrapped form)
+    if (rest[0] === '(') {
+      let depth = 0, i = 0;
+      while (i < rest.length) {
+        if (rest[i] === '(') depth++;
+        else if (rest[i] === ')' && --depth === 0) { i++; break; }
+        i++;
+      }
+      rest = rest.slice(i);
+      if (rest[0] === '?') rest = rest.slice(1);
+      const key = keys[ki++];
+      parts.push(`:${key ? key.name : `param${ki - 1}`}`);
+      continue;
+    }
+
+    // Backslash-escaped character (other than \/)
+    if (rest[0] === '\\' && rest.length > 1) {
+      parts.push(rest[1]);
+      rest = rest.slice(2);
+      continue;
+    }
+
+    // Literal character — stop at regex metacharacters
+    if (!/[\\()?$*+[\]|^]/.test(rest[0])) {
+      parts.push(rest[0]);
+      rest = rest.slice(1);
+      continue;
+    }
+
+    break;
+  }
+
+  return normalizePath(parts.join(''));
+}
+
+// Returns true when str is a (?:\/captureGroup) parameter wrapper, not a suffix.
+// Distinguishes (?:\/([^/]+?)) from (?:\/$) or (?:\/(?=$)).
+function isParamWrapper(str) {
+  const after = str.slice(3); // content after (?:
+  if (!after.startsWith('\\/')) return false;
+  const inner = after.slice(2); // content after (?:\/
+  return inner[0] === '(' &&
+    !inner.startsWith('(?:') &&
+    !inner.startsWith('(?=') &&
+    !inner.startsWith('(?!');
+}
+
+// Return the content inside the outermost (?:…) group, or null on parse failure.
+function unwrapNonCapturingGroup(str) {
+  let depth = 0, i = 0;
+  for (; i < str.length; i++) {
+    if (str[i] === '(') depth++;
+    else if (str[i] === ')' && --depth === 0) { i++; break; }
+  }
+  return depth === 0 ? str.slice(3, i - 1) : null;
+}
+
+function normalizePath(p) {
+  const s = ('/' + p).replace(/\/+/g, '/');
+  return s.length > 1 ? s.replace(/\/$/, '') : s;
+}
+
+function fmt(method, routePath) {
+  return `${method.toUpperCase()}   =>   ${routePath}`;
+}
 
 module.exports = registeredRoutes;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,159 @@
+'use strict';
+
+const assert = require('assert');
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const CLI = path.resolve(__dirname, '../bin/index.js');
+const FIXTURE_E4 = path.resolve(__dirname, 'fixtures/app-e4.js');
+const FIXTURE_E4_NOEXPORT = path.resolve(__dirname, 'fixtures/app-e4-noexport.js');
+const FIXTURE_E5 = path.resolve(__dirname, 'fixtures/app-e5.js');
+
+// Routes produced by the fixture apps (order-sensitive, matches registration order)
+const E4_ROUTES = [
+  'GET   =>   /api/users',
+  'POST   =>   /api/users',
+  'GET   =>   /api/users/:id',
+  'PUT   =>   /api/users/:id',
+  'DELETE   =>   /api/users/:id',
+  'GET   =>   /health',
+];
+
+const E5_ROUTES = [
+  'GET   =>   /api/items',
+  'POST   =>   /api/items',
+  'GET   =>   /api/items/:id',
+  'DELETE   =>   /api/items/:id',
+  'GET   =>   /health',
+  'GET   =>   /ping',
+  'GET   =>   /pong',
+];
+
+// Spawn `node bin/index.js [args]` with colors disabled, resolving paths from root.
+function runCLI(args) {
+  return new Promise(resolve => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      cwd: path.resolve(__dirname, '..'),
+      env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', d => { stdout += d.toString(); });
+    child.stderr.on('data', d => { stderr += d.toString(); });
+    child.on('close', code => resolve({ stdout, stderr, code }));
+  });
+}
+
+// Convert a routes array to the expected `--output print` string
+function toPrintOutput(routes) {
+  return routes
+    .map(r => {
+      const sep = '   =>   ';
+      const idx = r.indexOf(sep);
+      return `${r.slice(0, idx)}\t${r.slice(idx + sep.length)}`;
+    })
+    .join('\n') + '\n';
+}
+
+// ── Express 4.x ──────────────────────────────────────────────────────────────
+
+describe('CLI — Express 4.x', () => {
+  it('--output print: prints routes to stdout', async () => {
+    const { stdout, code } = await runCLI(['-p', FIXTURE_E4, '-v', 'app', '-o', 'print']);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(stdout, toPrintOutput(E4_ROUTES));
+  });
+
+  it('--output json: writes routes to a JSON file', async () => {
+    const out = path.join(os.tmpdir(), `erc-test-e4-${Date.now()}.json`);
+    try {
+      const { code } = await runCLI(['-p', FIXTURE_E4, '-v', 'app', '-o', 'json', '-f', out]);
+      assert.strictEqual(code, 0);
+      const { routes } = JSON.parse(fs.readFileSync(out, 'utf8'));
+      assert.deepStrictEqual(routes, E4_ROUTES);
+    } finally {
+      if (fs.existsSync(out)) fs.unlinkSync(out);
+    }
+  });
+
+  it('handles an app file without module.exports (temp-file path)', async () => {
+    const { stdout, code } = await runCLI(['-p', FIXTURE_E4_NOEXPORT, '-v', 'app', '-o', 'print']);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(stdout, toPrintOutput([
+      'GET   =>   /no-export',
+      'POST   =>   /no-export',
+    ]));
+  });
+});
+
+// ── Express 5.x ──────────────────────────────────────────────────────────────
+
+describe('CLI — Express 5.x', () => {
+  it('--output print: prints routes to stdout', async () => {
+    const { stdout, code } = await runCLI(['-p', FIXTURE_E5, '-v', 'app', '-o', 'print']);
+    assert.strictEqual(code, 0);
+    assert.strictEqual(stdout, toPrintOutput(E5_ROUTES));
+  });
+
+  it('--output json: writes routes to a JSON file', async () => {
+    const out = path.join(os.tmpdir(), `erc-test-e5-${Date.now()}.json`);
+    try {
+      const { code } = await runCLI(['-p', FIXTURE_E5, '-v', 'app', '-o', 'json', '-f', out]);
+      assert.strictEqual(code, 0);
+      const { routes } = JSON.parse(fs.readFileSync(out, 'utf8'));
+      assert.deepStrictEqual(routes, E5_ROUTES);
+    } finally {
+      if (fs.existsSync(out)) fs.unlinkSync(out);
+    }
+  });
+});
+
+// ── Error handling ────────────────────────────────────────────────────────────
+
+describe('CLI — error handling', () => {
+  it('exits 1 and reports file-not-found', async () => {
+    const { stdout, stderr, code } = await runCLI([
+      '-p', '/nonexistent/app.js', '-v', 'app', '-o', 'print',
+    ]);
+    assert.strictEqual(code, 1);
+    assert.ok(
+      (stdout + stderr).includes('File not found'),
+      `expected "File not found" in output, got: ${stdout}${stderr}`
+    );
+  });
+
+  it('exits 1 when the requested variable is not exported', async () => {
+    const { stdout, stderr, code } = await runCLI([
+      '-p', FIXTURE_E4, '-v', 'notExported', '-o', 'print',
+    ]);
+    assert.strictEqual(code, 1);
+    assert.ok(
+      (stdout + stderr).includes('notExported'),
+      `expected variable name in output, got: ${stdout}${stderr}`
+    );
+  });
+
+  it('exits 1 when --output json is used without --output-file', async () => {
+    const { stdout, stderr, code } = await runCLI([
+      '-p', FIXTURE_E4, '-v', 'app', '-o', 'json',
+    ]);
+    assert.strictEqual(code, 1);
+    assert.ok(
+      (stdout + stderr).toLowerCase().includes('output file'),
+      `expected output-file hint in output, got: ${stdout}${stderr}`
+    );
+  });
+
+  it('exits 1 for an unrecognised --output type', async () => {
+    const { stdout, stderr, code } = await runCLI([
+      '-p', FIXTURE_E4, '-v', 'app', '-o', 'xml',
+    ]);
+    assert.strictEqual(code, 1);
+    assert.ok(
+      (stdout + stderr).includes('xml'),
+      `expected invalid type in output, got: ${stdout}${stderr}`
+    );
+  });
+});

--- a/test/fixtures/app-e4-noexport.js
+++ b/test/fixtures/app-e4-noexport.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const express = require('express-v4');
+const app = express();
+
+app.get('/no-export', () => {});
+app.post('/no-export', () => {});

--- a/test/fixtures/app-e4.js
+++ b/test/fixtures/app-e4.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const express = require('express-v4');
+
+const app = express();
+
+const api = express.Router();
+api.get('/users', () => {});
+api.post('/users', () => {});
+api.get('/users/:id', () => {});
+api.put('/users/:id', () => {});
+api.delete('/users/:id', () => {});
+
+app.use('/api', api);
+app.get('/health', () => {});
+
+module.exports = { app };

--- a/test/fixtures/app-e5.js
+++ b/test/fixtures/app-e5.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const express = require('express-v5');
+
+const app = express();
+
+const api = express.Router();
+api.get('/items', () => {});
+api.post('/items', () => {});
+api.get('/items/:id', () => {});
+api.delete('/items/:id', () => {});
+
+app.use('/api', api);
+app.get('/health', () => {});
+app.get(['/ping', '/pong'], () => {}); // Express 5.x array paths
+
+module.exports = { app };

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -1,0 +1,356 @@
+'use strict';
+
+const assert = require('assert');
+const registeredRoutes = require('../plugin');
+
+const noop = () => {};
+
+// ── Express 3.x ──────────────────────────────────────────────────────────────
+// Express 3.x is incompatible with Node ≥18 so we test via a structural mock
+// that replicates the app.routes interface it exposes.
+
+describe('Express 3.x (mock)', () => {
+  const mockApp = {
+    routes: {
+      get:    [{ path: '/', method: 'get' }, { path: '/users', method: 'get' }],
+      post:   [{ path: '/users', method: 'post' }],
+      put:    [{ path: '/users/:id', method: 'put' }],
+      delete: [{ path: '/users/:id', method: 'delete' }],
+    },
+  };
+
+  it('returns flat routes from app.routes', () => {
+    assert.deepStrictEqual(registeredRoutes(mockApp, null).sort(), [
+      'DELETE   =>   /users/:id',
+      'GET   =>   /',
+      'GET   =>   /users',
+      'POST   =>   /users',
+      'PUT   =>   /users/:id',
+    ]);
+  });
+
+  it('returns [] for an empty app.routes object', () => {
+    assert.deepStrictEqual(registeredRoutes({ routes: {} }, null), []);
+  });
+
+  it('uppercases the HTTP method names', () => {
+    const app = { routes: { get: [{ path: '/x', method: 'get' }] } };
+    const [route] = registeredRoutes(app, null);
+    assert.ok(route.startsWith('GET'));
+  });
+});
+
+// ── Express 4.x ──────────────────────────────────────────────────────────────
+
+describe('Express 4.x', () => {
+  const express = require('express-v4');
+
+  it('returns [] when no routes are registered', () => {
+    assert.deepStrictEqual(registeredRoutes(express(), null), []);
+  });
+
+  it('handles all standard HTTP methods', () => {
+    const app = express();
+    app.get('/a', noop);
+    app.post('/b', noop);
+    app.put('/c', noop);
+    app.patch('/d', noop);
+    app.delete('/e', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'DELETE   =>   /e',
+      'GET   =>   /a',
+      'PATCH   =>   /d',
+      'POST   =>   /b',
+      'PUT   =>   /c',
+    ]);
+  });
+
+  it('preserves parameter names in flat route paths', () => {
+    const app = express();
+    app.get('/users/:userId/posts/:postId', noop);
+
+    assert.deepStrictEqual(
+      registeredRoutes(app, null),
+      ['GET   =>   /users/:userId/posts/:postId']
+    );
+  });
+
+  it('lists multiple methods on the same path as separate entries', () => {
+    const app = express();
+    app.get('/resource', noop);
+    app.post('/resource', noop);
+    app.delete('/resource', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'DELETE   =>   /resource',
+      'GET   =>   /resource',
+      'POST   =>   /resource',
+    ]);
+  });
+
+  it('prepends the mount path to nested router routes', () => {
+    const app = express();
+    const router = express.Router();
+    router.get('/list', noop);
+    router.post('/create', noop);
+    app.use('/items', router);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'GET   =>   /items/list',
+      'POST   =>   /items/create',
+    ]);
+  });
+
+  it('handles three levels of nested routers', () => {
+    const app = express();
+    const v1 = express.Router();
+    const users = express.Router();
+    users.get('/', noop);
+    users.get('/:id', noop);
+    users.post('/', noop);
+    v1.use('/users', users);
+    app.use('/api/v1', v1);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'GET   =>   /api/v1/users',
+      'GET   =>   /api/v1/users/:id',
+      'POST   =>   /api/v1/users',
+    ]);
+  });
+
+  it('handles root mount app.use("/", router)', () => {
+    const app = express();
+    const router = express.Router();
+    router.get('/ping', noop);
+    router.post('/ping', noop);
+    app.use('/', router);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'GET   =>   /ping',
+      'POST   =>   /ping',
+    ]);
+  });
+
+  it('handles multiple routers mounted at different paths', () => {
+    const app = express();
+    const auth = express.Router();
+    const data = express.Router();
+    auth.post('/login', noop);
+    auth.post('/logout', noop);
+    data.get('/items', noop);
+    data.delete('/items/:id', noop);
+    app.use('/auth', auth);
+    app.use('/data', data);
+    app.get('/health', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'DELETE   =>   /data/items/:id',
+      'GET   =>   /data/items',
+      'GET   =>   /health',
+      'POST   =>   /auth/login',
+      'POST   =>   /auth/logout',
+    ]);
+  });
+
+  it('preserves parameter names in a parameterized mount prefix', () => {
+    const app = express();
+    const router = express.Router();
+    router.get('/settings', noop);
+    app.use('/orgs/:orgId', router);
+
+    assert.deepStrictEqual(
+      registeredRoutes(app, null),
+      ['GET   =>   /orgs/:orgId/settings']
+    );
+  });
+
+  it('normalizes redundant slashes in paths', () => {
+    const app = express();
+    const router = express.Router();
+    router.get('/', noop);
+    app.use('/', router);
+
+    const routes = registeredRoutes(app, null);
+    assert.ok(routes.every(r => !r.includes('//')), `unexpected double slash: ${routes}`);
+  });
+
+  it('returns routes in registration order', () => {
+    const app = express();
+    app.get('/first', noop);
+    app.get('/second', noop);
+    app.get('/third', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null), [
+      'GET   =>   /first',
+      'GET   =>   /second',
+      'GET   =>   /third',
+    ]);
+  });
+
+  it('ignores pure middleware layers (no route, no stack)', () => {
+    const app = express();
+    app.use((req, res, next) => next()); // middleware-only layer
+    app.get('/real', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null), ['GET   =>   /real']);
+  });
+});
+
+// ── Express 5.x ──────────────────────────────────────────────────────────────
+
+describe('Express 5.x', () => {
+  const express = require('express-v5');
+
+  it('returns [] when no routes are registered', () => {
+    assert.deepStrictEqual(registeredRoutes(express(), null), []);
+  });
+
+  it('handles all standard HTTP methods', () => {
+    const app = express();
+    app.get('/a', noop);
+    app.post('/b', noop);
+    app.put('/c', noop);
+    app.patch('/d', noop);
+    app.delete('/e', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'DELETE   =>   /e',
+      'GET   =>   /a',
+      'PATCH   =>   /d',
+      'POST   =>   /b',
+      'PUT   =>   /c',
+    ]);
+  });
+
+  it('preserves parameter names in flat route paths', () => {
+    const app = express();
+    app.get('/users/:userId/posts/:postId', noop);
+
+    assert.deepStrictEqual(
+      registeredRoutes(app, null),
+      ['GET   =>   /users/:userId/posts/:postId']
+    );
+  });
+
+  it('handles array of paths on a single route handler (Express 5 feature)', () => {
+    const app = express();
+    app.get(['/ping', '/pong'], noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'GET   =>   /ping',
+      'GET   =>   /pong',
+    ]);
+  });
+
+  it('lists multiple methods on the same path as separate entries', () => {
+    const app = express();
+    app.get('/resource', noop);
+    app.post('/resource', noop);
+    app.delete('/resource', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'DELETE   =>   /resource',
+      'GET   =>   /resource',
+      'POST   =>   /resource',
+    ]);
+  });
+
+  it('prepends the mount path to nested router routes', () => {
+    const app = express();
+    const router = express.Router();
+    router.get('/list', noop);
+    router.post('/create', noop);
+    app.use('/items', router);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'GET   =>   /items/list',
+      'POST   =>   /items/create',
+    ]);
+  });
+
+  it('handles three levels of nested routers', () => {
+    const app = express();
+    const v1 = express.Router();
+    const users = express.Router();
+    users.get('/', noop);
+    users.get('/:id', noop);
+    users.post('/', noop);
+    v1.use('/users', users);
+    app.use('/api/v1', v1);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'GET   =>   /api/v1/users',
+      'GET   =>   /api/v1/users/:id',
+      'POST   =>   /api/v1/users',
+    ]);
+  });
+
+  it('handles root mount app.use("/", router)', () => {
+    const app = express();
+    const router = express.Router();
+    router.get('/ping', noop);
+    app.use('/', router);
+
+    assert.deepStrictEqual(registeredRoutes(app, null), ['GET   =>   /ping']);
+  });
+
+  it('handles multiple routers mounted at different paths', () => {
+    const app = express();
+    const auth = express.Router();
+    const data = express.Router();
+    auth.post('/login', noop);
+    data.get('/items', noop);
+    data.delete('/items/:id', noop);
+    app.use('/auth', auth);
+    app.use('/data', data);
+    app.get('/health', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null).sort(), [
+      'DELETE   =>   /data/items/:id',
+      'GET   =>   /data/items',
+      'GET   =>   /health',
+      'POST   =>   /auth/login',
+    ]);
+  });
+
+  it('uses generic :param names for a parameterized mount prefix (known limitation)', () => {
+    // Express 5 stores the compiled regexp inside a closure; param names from
+    // layer.keys are only populated after matching, not at inspection time.
+    const app = express();
+    const router = express.Router();
+    router.get('/settings', noop);
+    app.use('/orgs/:orgId', router);
+
+    const routes = registeredRoutes(app, null);
+    // Path structure must be correct even if param name is generic
+    assert.strictEqual(routes.length, 1);
+    assert.ok(
+      /^GET   =>   \/orgs\/:.*\/settings$/.test(routes[0]),
+      `unexpected route: ${routes[0]}`
+    );
+  });
+
+  it('normalizes redundant slashes in paths', () => {
+    const app = express();
+    const router = express.Router();
+    router.get('/', noop);
+    app.use('/', router);
+
+    const routes = registeredRoutes(app, null);
+    assert.ok(routes.every(r => !r.includes('//')), `unexpected double slash: ${routes}`);
+  });
+
+  it('returns routes in registration order', () => {
+    const app = express();
+    app.get('/first', noop);
+    app.get('/second', noop);
+    app.get('/third', noop);
+
+    assert.deepStrictEqual(registeredRoutes(app, null), [
+      'GET   =>   /first',
+      'GET   =>   /second',
+      'GET   =>   /third',
+    ]);
+  });
+});


### PR DESCRIPTION
- Updated package version in package.json from 1.2.3 to 2.0.0.
- Enhanced registeredRoutes function to support both Express 4.x and 5.x.
- Added new test cases for CLI functionality with Express 4.x and 5.x.
- Created fixture applications for testing Express 4.x and 5.x routes.
- Implemented error handling tests for CLI commands.
- Refactored route extraction logic to accommodate changes in Express 5.x.